### PR TITLE
Changed encoder type

### DIFF
--- a/src/main/java/com/sumologic/logback/SumoLogicAppender.java
+++ b/src/main/java/com/sumologic/logback/SumoLogicAppender.java
@@ -26,9 +26,9 @@
 
 package com.sumologic.logback;
 
-import ch.qos.logback.classic.encoder.PatternLayoutEncoder;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.UnsynchronizedAppenderBase;
+import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
 import ch.qos.logback.core.status.ErrorStatus;
 import com.sumologic.http.aggregation.SumoBufferFlusher;
 import com.sumologic.http.queue.BufferWithEviction;
@@ -50,7 +50,7 @@ import java.nio.charset.Charset;
 public class SumoLogicAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     private Logger logger = LoggerFactory.getLogger(getClass());
-    private PatternLayoutEncoder encoder = null;
+    private LayoutWrappingEncoder<ILoggingEvent> encoder = null;
     private String url = null;
 
     private String proxyHost = null;
@@ -82,11 +82,11 @@ public class SumoLogicAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
 
     // All the parameters exposed to Logback
 
-    public PatternLayoutEncoder getEncoder() {
+    public LayoutWrappingEncoder<ILoggingEvent> getEncoder() {
         return this.encoder;
     }
 
-    public void setEncoder(PatternLayoutEncoder encoder) {
+    public void setEncoder(LayoutWrappingEncoder<ILoggingEvent> encoder) {
         this.encoder = encoder;
     }
 


### PR DESCRIPTION
Changed encoder from a pattern layout encoder to a layout wrapping encoder so that json log messages can sent via http.
See issue #2

Example use would be something like:
`<appender name="sumo-logic" class="com.sumologic.logback.SumoLogicAppender">
        <url>http</url>
        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
            <layout class="ch.qos.logback.contrib.json.classic.JsonLayout">
                <timestampFormat>yyyy-MM-dd'T'HH:mm:ss.SSSX</timestampFormat>
                <timestampFormatTimezoneId>Etc/UTC</timestampFormatTimezoneId>
               <!-- custom multi line json formatter -->
                <jsonFormatter class="otm.sumoLogicLogTest.OtmJacksonJsonFormatter"/>
            </layout>
        </encoder>
    </appender>` 

(the jsonFormatter is supplied to add a line break between json log messages, this enables sumo to detect multiple log messages per http request and is optional)