### PR TITLE
Add retryableHttpCodeRegex for configurable HTTP retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Be sure to replace [collector-url] with the URL after creating an HTTP Hosted Co
 | flushingAccuracyMs      | No       | 250           | How often (in ms) that the flushing thread checks the message queue                                                                        |
 | maxQueueSizeBytes     | No       | 1000000       | Maximum capacity (in bytes) of the message queue
 | flushAllBeforeStopping| No       | true         | Flush all messages before stopping regardless of flushingAccuracyMs Be sure to call `loggerContext.stop();` when your application stops.
+| retryableHttpCodeRegex| No       | ^5.*         | Regular expression specifying which HTTP error code(s) should be retried during sending. By default, all 5xx error codes will be retried.
 
 #### Example with Optional Parameters
 

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>com.sumologic.plugins.http</groupId>
             <artifactId>sumologic-http-core</artifactId>
-            <version>1.3</version>
+            <version>1.4</version>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/src/main/java/com/sumologic/logback/SumoLogicAppender.java
+++ b/src/main/java/com/sumologic/logback/SumoLogicAppender.java
@@ -75,6 +75,8 @@ public class SumoLogicAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
 
     private long maxQueueSizeBytes = 1000000;
 
+    private String retryableHttpCodeRegex = "^5.*";
+
     private SumoHttpSender sender;
     private SumoBufferFlusher flusher;
     volatile private BufferWithEviction<String> queue;
@@ -212,6 +214,14 @@ public class SumoLogicAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
         this.flushAllBeforeStopping = flushAllBeforeStopping;
     }
 
+    public void setRetryableHttpCodeRegex(String retryableHttpCodeRegex) {
+        this.retryableHttpCodeRegex = retryableHttpCodeRegex;
+    }
+
+    public String getRetryableHttpCodeRegex() {
+        return retryableHttpCodeRegex;
+    }
+
     @Override
     public void start() {
         int errors = 0;
@@ -265,6 +275,7 @@ public class SumoLogicAppender extends UnsynchronizedAppenderBase<ILoggingEvent>
                 proxyPassword,
                 proxyDomain));
         sender.setClientHeaderValue(CLIENT_NAME);
+        sender.setRetryableHttpCodeRegex(retryableHttpCodeRegex);
         sender.init();
 
         // Initialize flusher


### PR DESCRIPTION
Adds a parameter for `retryableHttpCodeRegex` that is configurable with a regex string.  By default we have it match `^5.*` for all 5xx, but the user can override it however they want with a regular expression.

Based on https://github.com/SumoLogic/sumologic-java-http-core/pull/8